### PR TITLE
Panic mode

### DIFF
--- a/ParserObjects.Tests/Parsers/SynchronizeParserTests.cs
+++ b/ParserObjects.Tests/Parsers/SynchronizeParserTests.cs
@@ -1,0 +1,28 @@
+﻿using static ParserObjects.ParserMethods<char>;
+
+namespace ParserObjects.Tests.Parsers;
+
+public class SynchronizeParserTests
+{
+    [Test]
+    public void Parse_Success()
+    {
+        var parser = Synchronize(Match('A'), x => true);
+        var result = parser.Parse("A;B;C;D");
+        result.Success.Should().BeTrue();
+        result.Value.Should().Be('A');
+    }
+
+    [Test]
+    public void Parse_Panic1()
+    {
+        var parser = Synchronize(Match('B'), x => x == ';');
+        var result = parser.Parse("A;B;C;D");
+        result.Success.Should().BeFalse();
+        var errors = result.TryGetData<ErrorList>().Value;
+        errors.ErrorResults.Count.Should().Be(1);
+        var finalResult = result.TryGetData<IResult<char>>().Value;
+        finalResult.Success.Should().BeTrue();
+        finalResult.Value.Should().Be('B');
+    }
+}

--- a/ParserObjects.Tests/Parsers/SynchronizeParserTests.cs
+++ b/ParserObjects.Tests/Parsers/SynchronizeParserTests.cs
@@ -1,4 +1,5 @@
-﻿using static ParserObjects.ParserMethods<char>;
+﻿using System.Linq;
+using static ParserObjects.ParserMethods<char>;
 
 namespace ParserObjects.Tests.Parsers;
 
@@ -24,5 +25,62 @@ public class SynchronizeParserTests
         var finalResult = result.TryGetData<IResult<char>>().Value;
         finalResult.Success.Should().BeTrue();
         finalResult.Value.Should().Be('B');
+    }
+
+    [Test]
+    public void Parse_Panic3()
+    {
+        var parser = Synchronize(Match('D'), x => x == ';');
+        var result = parser.Parse("A;B;C;D");
+        result.Success.Should().BeFalse();
+        var errors = result.TryGetData<ErrorList>().Value;
+        errors.ErrorResults.Count.Should().Be(3);
+        var finalResult = result.TryGetData<IResult<char>>().Value;
+        finalResult.Success.Should().BeTrue();
+        finalResult.Value.Should().Be('D');
+    }
+
+    [Test]
+    public void Parse_PanicEndOfInput()
+    {
+        var parser = Synchronize(Match('X'), x => x == ';');
+        var result = parser.Parse("A;B;C;D");
+        result.Success.Should().BeFalse();
+        var errors = result.TryGetData<ErrorList>().Value;
+        errors.ErrorResults.Count.Should().Be(4);
+        var finalResult = result.TryGetData<IResult<char>>();
+        finalResult.Success.Should().BeFalse();
+    }
+
+    [Test]
+    public void Parse_EndOfInput()
+    {
+        var parser = Synchronize(Match('X'), x => x == ';');
+        var result = parser.Parse("");
+        result.Success.Should().BeFalse();
+        var errors = result.TryGetData<ErrorList>().Value;
+        errors.ErrorResults.Count.Should().Be(1);
+        var finalResult = result.TryGetData<IResult<char>>();
+        finalResult.Success.Should().BeFalse();
+    }
+
+    [Test]
+    public void GetChildren()
+    {
+        var inner = Match('X');
+        var parser = Synchronize(inner, x => x == ';');
+        var result = parser.GetChildren().ToList();
+        result.Count.Should().Be(1);
+        result[0].Should().BeSameAs(inner);
+    }
+
+    [Test]
+    public void SetName()
+    {
+        var parser = Synchronize(Match('X'), x => x == ';');
+        var result = parser.SetName("test");
+        result.Name.Should().Be("test");
+        parser.Name.Should().Be("");
+        result.Should().NotBeSameAs(parser);
     }
 }

--- a/ParserObjects/ErrorList.cs
+++ b/ParserObjects/ErrorList.cs
@@ -1,0 +1,5 @@
+﻿using System.Collections.Generic;
+
+namespace ParserObjects;
+
+public record ErrorList(IReadOnlyList<IResult> ErrorResults);

--- a/ParserObjects/ParserMethods.Basic.cs
+++ b/ParserObjects/ParserMethods.Basic.cs
@@ -423,6 +423,9 @@ public static partial class ParserMethods<TInput>
     public static IParser<TInput, TOutput> Sequential<TOutput>(Func<Sequential.State<TInput>, TOutput> func)
         => new Sequential.Parser<TInput, TOutput>(func);
 
+    public static IParser<TInput, TOutput> Synchronize<TOutput>(IParser<TInput, TOutput> attempt, Func<TInput, bool> discardUntil)
+        => new SynchronizeParser<TInput, TOutput>(attempt, discardUntil);
+
     /// <summary>
     /// Transform the output value of the parser.
     /// </summary>

--- a/ParserObjects/ParserMethods.Basic.cs
+++ b/ParserObjects/ParserMethods.Basic.cs
@@ -423,6 +423,16 @@ public static partial class ParserMethods<TInput>
     public static IParser<TInput, TOutput> Sequential<TOutput>(Func<Sequential.State<TInput>, TOutput> func)
         => new Sequential.Parser<TInput, TOutput>(func);
 
+    /// <summary>
+    /// Attempt the parse. Return on success. On failure, enter "panic mode" where input tokens can be
+    /// discarded until the next "good" location and the parse will be attempted again. Subsequent
+    /// attempts will always return failure, but with error information about all the errors which
+    /// were seen.
+    /// </summary>
+    /// <typeparam name="TOutput"></typeparam>
+    /// <param name="attempt"></param>
+    /// <param name="discardUntil"></param>
+    /// <returns></returns>
     public static IParser<TInput, TOutput> Synchronize<TOutput>(IParser<TInput, TOutput> attempt, Func<TInput, bool> discardUntil)
         => new SynchronizeParser<TInput, TOutput>(attempt, discardUntil);
 

--- a/ParserObjects/Parsers/SynchronizeParser.cs
+++ b/ParserObjects/Parsers/SynchronizeParser.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using ParserObjects.Utility;
+
+namespace ParserObjects.Parsers;
+
+/// <summary>
+/// Panic mode handler. Attempt the parse and return immediately if successful.
+/// On error, discard input tokens until a known-good state is reached and
+/// continue the attempt from the new location. Returns failure if the first
+/// attempt does not succeed, but includes information about all subsequent
+/// attempts.
+/// </summary>
+/// <typeparam name="TInput"></typeparam>
+/// <typeparam name="TOutput"></typeparam>
+/// <param name="Attempt"></param>
+/// <param name="DiscardUntil"></param>
+/// <param name="Name"></param>
+public sealed record SynchronizeParser<TInput, TOutput>(
+    IParser<TInput, TOutput> Attempt,
+    Func<TInput, bool> DiscardUntil,
+    string Name = ""
+) : IParser<TInput, TOutput>
+{
+    public int Id { get; } = UniqueIntegerGenerator.GetNext();
+
+    public IEnumerable<IParser> GetChildren() => new[] { Attempt };
+
+    public IResult<TOutput> Parse(IParseState<TInput> state)
+    {
+        var result = Attempt.Parse(state);
+        if (result.Success)
+            return result;
+
+        var allErrors = new List<IResult>
+        {
+            result
+        };
+
+        // Result failed. Enter a loop to discard tokens and try again.
+        while (!state.Input.IsAtEnd)
+        {
+            // Outer loop: Discard a bunch of tokens and then attempt the parse
+            // again from a "good" location. Keep doing this until we have a success
+            // or we run out of input
+
+            DiscardUntilConditionMet(state);
+            if (state.Input.IsAtEnd)
+                break;
+
+            result = Attempt.Parse(state);
+            if (result.Success)
+                break;
+            allErrors.Add(result);
+        }
+
+        // At this point we have panic'd so we're always going to return a failure.
+        // Append all the data necessary so the caller can examine what's going on.
+        var data = new List<object>
+        {
+            new ErrorList(allErrors)
+        };
+        if (result.Success)
+            data.Add(result);
+
+        return state.Fail(this, "One or more errors occured. Call IResult<T>.TryGetData<ErrorList>() for more details", data);
+    }
+
+    private void DiscardUntilConditionMet(IParseState<TInput> state)
+    {
+        while (!state.Input.IsAtEnd)
+        {
+            // Inner loop: Discard a token. If the DiscardUntil condition is
+            // met, or we run out of inputs, stop discarding.
+            var discard = state.Input.GetNext();
+            if (DiscardUntil(discard))
+                break;
+        }
+    }
+
+    public INamed SetName(string name) => this with { Name = name };
+
+    IResult IParser<TInput>.Parse(IParseState<TInput> state) => Parse(state);
+}


### PR DESCRIPTION
`SynchronizeParser` implements error-recovery through panic mode. The inner parser is attempted and, if successful, returns immediately.

If the initial attempt fails, the parser enters **panic mode**. From this point the entire parse is considered a failure, but it is desired that additional parse errors are found and reported before aborting. Once in panic mode, the parser discards tokens until a known "good" state, and then attempts the parse again from that point. It does this in a loop until the input is exhausted or an attempt is successful. 

All errors from all attempts while in panic mode are recorded and returned in the result. If an attempt eventually does succeed, that information is also returned.
```csharp
var result = parser.Parse(...);
var errors = result.TryGetData<ErrorList>().Value;
var successResult = result.TryGetData<IResult>;
```

